### PR TITLE
Jobfactory take groupName into account

### DIFF
--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/DropwizardJobFactory.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/DropwizardJobFactory.java
@@ -1,11 +1,13 @@
 package de.spinscale.dropwizard.jobs;
 
-import org.quartz.Job;
+import java.util.Objects;
 import org.quartz.JobDetail;
+import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
+import org.quartz.utils.Key;
 
 class DropwizardJobFactory implements JobFactory {
 
@@ -18,11 +20,18 @@ class DropwizardJobFactory implements JobFactory {
     @Override
     public Job newJob(TriggerFiredBundle bundle, Scheduler scheduler) throws SchedulerException {
         JobDetail jobDetail = bundle.getJobDetail();
+        JobKey jobKey = jobDetail.getKey();
+
         for (Job job : jobs) {
-            if (job.getClass().equals(jobDetail.getJobClass())) {
+            if (job.getClass().equals(jobDetail.getJobClass()) && equalGroupName(job, jobKey)) {
                 return job;
             }
         }
         return null;
+    }
+
+    private boolean equalGroupName(final Job job, final JobKey quartzJobKey) {
+        return Key.DEFAULT_GROUP.equals(quartzJobKey.getGroup()) && job.getGroupName() == null
+            || Objects.equals(job.getGroupName(), quartzJobKey.getGroup());
     }
 }


### PR DESCRIPTION
We recently added ability to specify a groupName for a scheduled job.
This means we can schedule multiple instances of the same class on the scheduler, as long as the groupName is different.

When Quartz is requesting an instance of the job to run, the current solution finds the job by class only.
This is not good enough, it also needs to take the groupName into account when comparing the jobs in the bundle.

So this is a fix, in order for the jobfactory to work properly.